### PR TITLE
Remove incorrect SRI hash from bootstrap script

### DIFF
--- a/index.html
+++ b/index.html
@@ -111,7 +111,7 @@
     </div>
   </footer>
 
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-pprn3073KE6tl6vLE6eT5Kk62gXtEZPONWs5mLZ49I+c4ExogKc5PQ5wE0h+XW70" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
   <script src="js/courses-data.js"></script>
   <script>
     // populate popular courses (first three from data)


### PR DESCRIPTION
## Summary
- remove outdated `integrity` attribute from Bootstrap bundle script in `index.html`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68934f4b773c832c976c8910571c6015