### PR TITLE
fix: update Formspree URL in contact form

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -29,7 +29,7 @@
 
   <main class="container mt-5 pt-4">
     <h1 class="my-4 text-center">Enroll Now</h1>
-    <form action="https://formspree.io/f/your-form-id" method="POST" class="row g-3">
+    <form action="https://formspree.io/f/xnnzgrye" method="POST" class="row g-3">
       <div class="col-md-6">
         <label for="name" class="form-label">Name</label>
         <input type="text" class="form-control" id="name" name="name" required />


### PR DESCRIPTION
## Summary
- point contact form to new Formspree endpoint

## Testing
- `npm test` *(fails: enoent Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899d446fc44832c97f688ad56bd12f4